### PR TITLE
add missing cmake options for win

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,9 @@ cmake %CMAKE_ARGS% ^
   -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
   -DCMAKE_INSTALL_LIBDIR=lib ^
   -DBUILD_SHARED_LIBS=ON ^
+  -DWITH_F12=ON ^
+  -DWITH_RANGE_COULOMB=ON ^
+  -DWITH_COULOMB_ERF=ON
 
 
 cmake --build build --parallel %CPU_COUNT% --verbose

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Fix-test-location.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage(name, min_pin='x.x', max_pin='x.x') }}
   force_ignore_keys:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

add three cmake options for win build script to make it consistent with linux. (did not notice this until I found the win-64 package is much smaller than linux ones)